### PR TITLE
Flush on endpoint.

### DIFF
--- a/src/main/java/org/apache/spark/shuffle/ucx/reducer/compat/spark_2_1/UcxShuffleClient.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/reducer/compat/spark_2_1/UcxShuffleClient.java
@@ -95,8 +95,7 @@ public class UcxShuffleClient extends ShuffleClient {
     submitFetchOffsets(endpoint, shuffleBlockIds, dataAddresses, offsetMemory);
 
     // flush guarantees that all that requests completes when callback is called.
-    // TODO: fix https://github.com/openucx/ucx/issues/4267 and use endpoint flush.
-    workerWrapper.worker().flushNonBlocking(
+    endpoint.flushNonBlocking(
       new OnOffsetsFetchCallback(shuffleBlockIds, endpoint, listener, offsetMemory,
         dataAddresses, dataRkeysCache));
     shuffleReadMetrics.incFetchWaitTime(System.currentTimeMillis() - startTime);

--- a/src/main/java/org/apache/spark/shuffle/ucx/reducer/compat/spark_2_4/UcxShuffleClient.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/reducer/compat/spark_2_4/UcxShuffleClient.java
@@ -95,8 +95,7 @@ public class UcxShuffleClient extends ShuffleClient {
     submitFetchOffsets(endpoint, shuffleBlockIds, dataAddresses, offsetMemory);
 
     // flush guarantees that all that requests completes when callback is called.
-    // TODO: fix https://github.com/openucx/ucx/issues/4267 and use endpoint flush.
-    workerWrapper.worker().flushNonBlocking(
+    endpoint.flushNonBlocking(
       new OnOffsetsFetchCallback(shuffleBlockIds, endpoint, listener, offsetMemory,
         dataAddresses, dataRkeysCache));
     shuffleReadMetrics.incFetchWaitTime(System.currentTimeMillis() - startTime);

--- a/src/main/java/org/apache/spark/shuffle/ucx/reducer/compat/spark_3_0/UcxShuffleClient.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/reducer/compat/spark_3_0/UcxShuffleClient.java
@@ -118,8 +118,7 @@ public class UcxShuffleClient extends BlockStoreClient {
     submitFetchOffsets(endpoint, blocks, offsetMemory, dataAddresses);
 
     // flush guarantees that all that requests completes when callback is called.
-    // TODO: fix https://github.com/openucx/ucx/issues/4267 and use endpoint flush.
-    workerWrapper.worker().flushNonBlocking(
+    endpoint.flushNonBlocking(
       new OnOffsetsFetchCallback(blocks, endpoint, listener, offsetMemory,
         dataAddresses, dataRkeysCache, mapId2PartitionId));
 


### PR DESCRIPTION
https://github.com/openucx/ucx/issues/4267 - already fixed, so doing flush on endpoint to prevent failures on a worker on many executors (1000), and speedup operations:
```
[tdw-11-73-85-143:14961:0:15598]      ucp_ep.c:290  Assertion `ep->refcount < (255)' failed

/data/ucx-1.11.0/src/ucp/core/ucp_ep.c: [ ucp_ep_add_ref() ]
      ...
      287 
      288 void ucp_ep_add_ref(ucp_ep_h ep)
      289 {
==>   290     ucs_assert(ep->refcount < UINT8_MAX);
      291     ++ep->refcount;
      292 }
      293 

==== backtrace (tid:  15598) ====
 0 0x0000000000029728 ucp_ep_add_ref()  /data/ucx-1.11.0/src/ucp/core/ucp_ep.c:290
 1 0x000000000005c64c ucp_worker_flush_req_set_next_ep()  /data/ucx-1.11.0/src/ucp/rma/flush.c:443
 2 0x000000000005c64c ucp_worker_flush_nbx_internal()  /data/ucx-1.11.0/src/ucp/rma/flush.c:571
 3 0x000000000005c64c ucp_worker_flush_nbx()  /data/ucx-1.11.0/src/ucp/rma/flush.c:596
 4 0x0000000000008c5f Java_org_openucx_jucx_ucp_UcpWorker_flushNonBlockingNative()  /data/ucx-1.11.0/bindings/java/src/main/native/worker.cc:136
=================================
```