### PR TITLE
Load UCX libs explicitly

### DIFF
--- a/src/main/scala/org/apache/spark/shuffle/ucx/CommonUcxShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/ucx/CommonUcxShuffleManager.scala
@@ -14,6 +14,7 @@ import org.apache.spark.shuffle.ucx.rpc.UcxRpcMessages.{ExecutorAdded, Introduce
 import org.apache.spark.shuffle.ucx.utils.SerializableDirectBuffer
 import org.apache.spark.util.{RpcUtils, ThreadUtils}
 import org.apache.spark.{SecurityManager, SparkConf, SparkEnv}
+import org.openucx.jucx.NativeLibs
 
 /**
  * Common part for all spark versions for UcxShuffleManager logic
@@ -22,6 +23,10 @@ abstract class CommonUcxShuffleManager(val conf: SparkConf, isDriver: Boolean) e
   type ShuffleId = Int
   type MapId = Int
   type ReduceId = Long
+
+  if (!isDriver) {
+    NativeLibs.load();
+  }
 
   val ucxShuffleConf = new UcxShuffleConf(conf)
 

--- a/src/main/scala/org/apache/spark/shuffle/ucx/CommonUcxShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/ucx/CommonUcxShuffleManager.scala
@@ -23,7 +23,8 @@ abstract class CommonUcxShuffleManager(val conf: SparkConf, isDriver: Boolean) e
   type ShuffleId = Int
   type MapId = Int
   type ReduceId = Long
-
+  
+  /* Load UCX/JUCX libraries as soon as possible to avoid collision with JVM when register malloc/mmap hook. */
   if (!isDriver) {
     NativeLibs.load();
   }


### PR DESCRIPTION
# What
 Fix SIGSEGV issue when JVM calls malloc

# Why ?
UCX should be initialized in the main thread ASAP to avoid collisions with JVM when malloc/mmap hook is registered.

# How ?
Load the UCX library once UCX shuffle manager is created.