### PR TITLE
add synchronization for transport initialization

### DIFF
--- a/src/main/scala/org/apache/spark/shuffle/compat/spark_2_4/UcxShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/compat/spark_2_4/UcxShuffleManager.scala
@@ -14,7 +14,7 @@ import org.apache.spark.{SparkConf, TaskContext}
  */
 class UcxShuffleManager(override val conf: SparkConf, isDriver: Boolean)
   extends CommonUcxShuffleManager(conf, isDriver) {
-
+  private[this] lazy val transport = awaitUcxTransport
   /**
    * Mapper callback on executor. Just start UcxNode and use Spark mapper logic.
    */
@@ -31,7 +31,7 @@ class UcxShuffleManager(override val conf: SparkConf, isDriver: Boolean)
   override def getReader[K, C](handle: ShuffleHandle, startPartition: Int,
                                endPartition: Int, context: TaskContext): ShuffleReader[K, C] = {
     new UcxShuffleReader(handle.asInstanceOf[BaseShuffleHandle[K,_,C]], startPartition,
-      endPartition, context, ucxTransport)
+      endPartition, context, transport)
   }
 }
 

--- a/src/main/scala/org/apache/spark/shuffle/compat/spark_3_0/UcxShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/compat/spark_3_0/UcxShuffleManager.scala
@@ -20,6 +20,7 @@ class UcxShuffleManager(override val conf: SparkConf, isDriver: Boolean)
   extends CommonUcxShuffleManager(conf, isDriver) {
 
   private lazy val shuffleExecutorComponents = loadShuffleExecutorComponents(conf)
+  private[this] lazy val transport = awaitUcxTransport
 
   override val shuffleBlockResolver = new UcxShuffleBlockResolver(this)
 
@@ -46,7 +47,7 @@ class UcxShuffleManager(override val conf: SparkConf, isDriver: Boolean)
   override def getReader[K, C](handle: ShuffleHandle, startPartition: MapId, endPartition: MapId,
                                context: TaskContext, metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
     new UcxShuffleReader(handle.asInstanceOf[BaseShuffleHandle[K,_,C]], startPartition, endPartition,
-      context, ucxTransport, readMetrics = metrics, shouldBatchFetch = false)
+      context, transport, readMetrics = metrics, shouldBatchFetch = false)
   }
 
   private def loadShuffleExecutorComponents(conf: SparkConf): ShuffleExecutorComponents = {

--- a/src/main/scala/org/apache/spark/shuffle/ucx/CommonUcxShuffleBlockResolver.scala
+++ b/src/main/scala/org/apache/spark/shuffle/ucx/CommonUcxShuffleBlockResolver.scala
@@ -26,6 +26,7 @@ abstract class CommonUcxShuffleBlockResolver(ucxShuffleManager: CommonUcxShuffle
   extends IndexShuffleBlockResolver(ucxShuffleManager.conf) {
 
   private val openFds = new ConcurrentHashMap[ShuffleId, ConcurrentLinkedQueue[RandomAccessFile]]()
+  private[ucx] lazy val transport = ucxShuffleManager.awaitUcxTransport
 
   /**
    * Mapper commit protocol extension. Register index and data files and publish all needed
@@ -49,7 +50,7 @@ abstract class CommonUcxShuffleBlockResolver(ucxShuffleManager: CommonUcxShuffle
 
           override def getSize: Long = blockLength
         }
-        ucxShuffleManager.ucxTransport.register(blockId, block)
+        transport.register(blockId, block)
         offset += blockLength
       }
     }


### PR DESCRIPTION
Add latch for synchronization of transport initialize,
in case that the spark tasks try to get writer/reader before the transport initialization finished.